### PR TITLE
refactor: Register the implementation of IRecordStorage with services

### DIFF
--- a/samples/HelloRin/Startup.cs
+++ b/samples/HelloRin/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -35,14 +35,15 @@ namespace HelloRin
 
             services.AddRin(options =>
             {
-                // Optional: Use Redis as storage
-                // options.RequestRecorder.StorageFactory = Rin.Storage.Redis.RedisRecordStorage.DefaultFactoryWithOptions(redisOptions =>
-                // {
-                //     redisOptions.ConnectionConfiguration = "[host]";
-                // });
                 options.RequestRecorder.RetentionMaxRequests = 100;
                 options.RequestRecorder.Excludes.Add(request => request.Path.Value.EndsWith(".js") || request.Path.Value.EndsWith(".css") || request.Path.Value.EndsWith(".svg"));
                 options.Inspector.ResponseBodyDataTransformers.Add(new RinCustomContentTypeTransformer());
+            });
+
+            // Optional: Use Redis as storage
+            services.AddRinRedisStorage(options =>
+            {
+                options.ConnectionConfiguration = "localhost:6379";
             });
         }
 

--- a/samples/HelloRin/Startup.cs
+++ b/samples/HelloRin/Startup.cs
@@ -41,10 +41,10 @@ namespace HelloRin
             });
 
             // Optional: Use Redis as storage
-            services.AddRinRedisStorage(options =>
-            {
-                options.ConnectionConfiguration = "localhost:6379";
-            });
+            //services.AddRinRedisStorage(options =>
+            //{
+            //    options.ConnectionConfiguration = "localhost:6379";
+            //});
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Rin.Storage.Redis/RedisRecordStorageOptions.cs
+++ b/src/Rin.Storage.Redis/RedisRecordStorageOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Rin.Storage.Redis
 {
@@ -13,11 +13,6 @@ namespace Rin.Storage.Redis
         /// A prefix of the Redis keys for Rin records. If Rin is running on multiple applications, you can change the prefix to separate records.
         /// </summary>
         public string KeyPrefix { get; set; } = "Rin.Storage.";
-
-        /// <summary>
-        /// Maximum count of requests retention.
-        /// </summary>
-        public int RetentionMaxRequests { get; set; } = 100;
 
         /// <summary>
         /// Redis database for Rin records.

--- a/src/Rin.Storage.Redis/RinRedisRecordStorageServiceExtensions.cs
+++ b/src/Rin.Storage.Redis/RinRedisRecordStorageServiceExtensions.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public static class RinRedisRecordStorageServiceExtensions
     {
+        /// <summary>
+        /// Add the Redis-backed <see cref="IRecordStorage"/> service and options.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configure"></param>
         public static void AddRinRedisStorage(this IServiceCollection services, Action<RedisRecordStorageOptions>? configure = null)
         {
             services.AddOptions<RedisRecordStorageOptions>();

--- a/src/Rin.Storage.Redis/RinRedisRecordStorageServiceExtensions.cs
+++ b/src/Rin.Storage.Redis/RinRedisRecordStorageServiceExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rin.Core.Record;
+using Rin.Storage.Redis;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class RinRedisRecordStorageServiceExtensions
+    {
+        public static void AddRinRedisStorage(this IServiceCollection services, Action<RedisRecordStorageOptions>? configure = null)
+        {
+            services.AddOptions<RedisRecordStorageOptions>();
+            services.Configure<RedisRecordStorageOptions>(configure);
+
+            services.Replace(new ServiceDescriptor(typeof(IRecordStorage), typeof(RedisRecordStorage), ServiceLifetime.Singleton));
+        }
+    }
+}

--- a/src/Rin/Core/RequestRecorderOptions.cs
+++ b/src/Rin/Core/RequestRecorderOptions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Rin.Core.Record;
 using Rin.Core.Storage;
 using System;
@@ -15,7 +15,5 @@ namespace Rin.Core
         public bool EnableBodyCapturing { get; set; } = true;
 
         public bool AllowRunningOnProduction { get; set; } = false;
-
-        public Func<IServiceProvider, IRecordStorage> StorageFactory { get; set; } = InMemoryRecordStorage.Factory;
     }
 }

--- a/src/Rin/Core/Storage/InMemoryRecordStorage.cs
+++ b/src/Rin/Core/Storage/InMemoryRecordStorage.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Rin.Core.Event;
 using Rin.Core.Record;
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Rin.Core.Storage
 {
@@ -14,19 +15,14 @@ namespace Rin.Core.Storage
     /// </summary>
     public class InMemoryRecordStorage : IRecordStorage
     {
-        private Dictionary<string, RecordEntry> _entries = new Dictionary<string, RecordEntry>();
-        private Queue<string> _entryIds = new Queue<string>();
-        private int _retentionMaxRequests = 100;
-        private ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+        private readonly Dictionary<string, RecordEntry> _entries = new Dictionary<string, RecordEntry>();
+        private readonly Queue<string> _entryIds = new Queue<string>();
+        private readonly int _retentionMaxRequests = 100;
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
 
-        public static readonly Func<IServiceProvider, IRecordStorage> Factory = (services) =>
+        public InMemoryRecordStorage(IOptions<RinOptions> options)
         {
-            return new InMemoryRecordStorage(services.GetService<RinOptions>().RequestRecorder.RetentionMaxRequests);
-        };
-
-        public InMemoryRecordStorage(int retentionMaxRequests)
-        {
-            _retentionMaxRequests = retentionMaxRequests;
+            _retentionMaxRequests = options.Value.RequestRecorder.RetentionMaxRequests;
         }
 
         public Task AddAsync(HttpRequestRecord record)

--- a/src/Rin/Extensions/RinSerivceExtensions.cs
+++ b/src/Rin/Extensions/RinSerivceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Rin.Channel;
+using Rin.Channel;
 using Rin.Core;
 using Rin.Core.Event;
 using Rin.Core.Record;
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Rin.Features;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -28,7 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var transformers = serviceProvider.GetServices<IBodyDataTransformer>().ToArray();
                 return new BodyDataTransformerSet(new BodyDataTransformerPipeline(transformers), new BodyDataTransformerPipeline(transformers));
             });
-            services.AddSingleton<IRecordStorage>(options.RequestRecorder.StorageFactory);
+            services.TryAddSingleton<IRecordStorage, InMemoryRecordStorage>();
             services.AddSingleton<IMessageEventBus<RequestEventMessage>>(new MessageEventBus<RequestEventMessage>());
             services.AddSingleton<IMessageEventBus<StoreBodyEventMessage>>(new MessageEventBus<StoreBodyEventMessage>());
             services.AddSingleton<RinOptions>(options);

--- a/src/Rin/Middlewares/RequestRecorderMiddleware.cs
+++ b/src/Rin/Middlewares/RequestRecorderMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Rin.Channel;


### PR DESCRIPTION
## Breaking changes
Remove `StorageFactory` property from `RinOptions`.

If the application uses Redis-backed storage, use `AddRinRedisStorage` method instead of the StorageFactory.
```csharp
services.AddRinRedisStorage(options =>
{
    options.ConnectionConfiguration = "localhost:6379";
});
```