### PR TITLE
refactor: Remove BodyDataTransformer options

### DIFF
--- a/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
+++ b/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Primitives;
 using Rin.Core;
 using Rin.Core.Record;
 using System;
@@ -10,14 +10,14 @@ using static HelloRin.Controllers.MyApiController;
 
 namespace HelloRin.Models
 {
-    public class RinCustomContentTypeTransformer : BodyDataTransformer
+    public class RinCustomContentTypeTransformer : IBodyDataTransformer
     {
-        public override bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues)
+        public bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues)
         {
             return contentTypeHeaderValues.Any(x => x == "application/x-msgpack");
         }
 
-        public override BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues)
+        public BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues)
         {
             var data = MessagePack.LZ4MessagePackSerializer.Deserialize<MyClass>(body, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var json = MessagePack.MessagePackSerializer.ToJson<MyClass>(data, MessagePack.Resolvers.ContractlessStandardResolver.Instance);

--- a/samples/HelloRin/Startup.cs
+++ b/samples/HelloRin/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Rin.Core;
 
 namespace HelloRin
 {
@@ -37,8 +38,8 @@ namespace HelloRin
             {
                 options.RequestRecorder.RetentionMaxRequests = 100;
                 options.RequestRecorder.Excludes.Add(request => request.Path.Value.EndsWith(".js") || request.Path.Value.EndsWith(".css") || request.Path.Value.EndsWith(".svg"));
-                options.Inspector.ResponseBodyDataTransformers.Add(new RinCustomContentTypeTransformer());
             });
+            services.AddSingleton<IBodyDataTransformer, RinCustomContentTypeTransformer>();
 
             // Optional: Use Redis as storage
             //services.AddRinRedisStorage(options =>

--- a/src/Rin/Core/BodyDataTransformer.cs
+++ b/src/Rin/Core/BodyDataTransformer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Primitives;
 using Rin.Core.Record;
 using System.Linq;
 
@@ -10,9 +10,11 @@ namespace Rin.Core
         BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues);
     }
 
-    public abstract class BodyDataTransformer : IBodyDataTransformer
+    public interface IRequestBodyDataTransformer : IBodyDataTransformer
     {
-        public abstract bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues);
-        public abstract BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues);
+    }
+
+    public interface IResponseBodyDataTransformer : IBodyDataTransformer
+    {
     }
 }

--- a/src/Rin/Core/InspectorOptions.cs
+++ b/src/Rin/Core/InspectorOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +7,5 @@ namespace Rin.Core
     public class InspectorOptions
     {
         public string MountPath { get; set; } = "/rin";
-        public List<IBodyDataTransformer> RequestBodyDataTransformers { get; } = new List<IBodyDataTransformer>();
-        public List<IBodyDataTransformer> ResponseBodyDataTransformers { get; } = new List<IBodyDataTransformer>();
     }
 }

--- a/src/Rin/Extensions/RinSerivceExtensions.cs
+++ b/src/Rin/Extensions/RinSerivceExtensions.cs
@@ -26,8 +26,11 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IRinRequestRecordingFeatureAccessor>(new RinRequestRecordingFeatureAccessor());
             services.AddSingleton<BodyDataTransformerSet>(serviceProvider =>
             {
-                var transformers = serviceProvider.GetServices<IBodyDataTransformer>().ToArray();
-                return new BodyDataTransformerSet(new BodyDataTransformerPipeline(transformers), new BodyDataTransformerPipeline(transformers));
+                var requestTransformers = serviceProvider.GetServices<IRequestBodyDataTransformer>();
+                var responseTransformers = serviceProvider.GetServices<IResponseBodyDataTransformer>();
+                var transformers = serviceProvider.GetServices<IBodyDataTransformer>();
+
+                return new BodyDataTransformerSet(new BodyDataTransformerPipeline(requestTransformers.Concat(transformers)), new BodyDataTransformerPipeline(responseTransformers.Concat(transformers)));
             });
             services.TryAddSingleton<IRecordStorage, InMemoryRecordStorage>();
             services.AddSingleton<IMessageEventBus<RequestEventMessage>>(new MessageEventBus<RequestEventMessage>());


### PR DESCRIPTION
## Breaking changes
Register your `IBodyDataTransformer` to service instead of using the `RequestBodyDataTransformers` or `ResponseBodyDataTransformers` options.

- `IBodyDataTransformer`: transformer for request and response data
- `IRequestBodyDataTransformer`: transformer for request data
- `IResponseBodyDataTransformer`: transformer for response data