### PR TITLE
refactor: Transformer API

### DIFF
--- a/samples/HelloRin/Controllers/MyApiController.cs
+++ b/samples/HelloRin/Controllers/MyApiController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using HelloRin.Models;
 using log4net;
+using MessagePack;
+using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -96,7 +98,7 @@ namespace HelloRin.Controllers
         // See RinCustomContentTypeTransformer class in this project.
         public IActionResult CustomContentType()
         {
-            var data = MessagePack.LZ4MessagePackSerializer.Serialize(new MyClass
+            var data = MessagePackSerializer.Serialize(new MyClass
             {
                 ValueA = "ValueA12345",
                 ValueB = 123,
@@ -115,7 +117,7 @@ namespace HelloRin.Controllers
                         ValueE = new[] { x.ToString() }
                     }
                 }).ToArray()
-            }, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            }, ContractlessStandardResolver.Options);
 
             return File(data, "application/x-msgpack");
         }

--- a/samples/HelloRin/HelloRin.csproj
+++ b/samples/HelloRin/HelloRin.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="MessagePack" Version="1.7.3.4" />
+    <PackageReference Include="MessagePack" Version="2.2.60" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
 
   </ItemGroup>

--- a/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
+++ b/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using MessagePack;
 using static HelloRin.Controllers.MyApiController;
 
 namespace HelloRin.Models
@@ -19,10 +20,9 @@ namespace HelloRin.Models
 
         public bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result)
         {
-            var data = MessagePack.LZ4MessagePackSerializer.Deserialize<MyClass>(body.ToArray(), MessagePack.Resolvers.ContractlessStandardResolver.Instance);
-            var json = MessagePack.MessagePackSerializer.ToJson<MyClass>(data, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            var json = MessagePackSerializer.ConvertToJson(body.ToArray(), MessagePack.Resolvers.ContractlessStandardResolver.Options);
 
-            result = new BodyDataTransformResult(new UTF8Encoding(false).GetBytes(json), contentTypeHeaderValues.ToString(), "application/json");
+            result = new BodyDataTransformResult(Encoding.UTF8.GetBytes(json), contentTypeHeaderValues.ToString(), "application/json");
             return true;
         }
     }

--- a/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
+++ b/samples/HelloRin/Models/RinCustomContentTypeTransformer.cs
@@ -17,12 +17,13 @@ namespace HelloRin.Models
             return contentTypeHeaderValues.Any(x => x == "application/x-msgpack");
         }
 
-        public BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues)
+        public bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result)
         {
-            var data = MessagePack.LZ4MessagePackSerializer.Deserialize<MyClass>(body, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
+            var data = MessagePack.LZ4MessagePackSerializer.Deserialize<MyClass>(body.ToArray(), MessagePack.Resolvers.ContractlessStandardResolver.Instance);
             var json = MessagePack.MessagePackSerializer.ToJson<MyClass>(data, MessagePack.Resolvers.ContractlessStandardResolver.Instance);
 
-            return new BodyDataTransformResult(new UTF8Encoding(false).GetBytes(json), contentTypeHeaderValues.ToString(), "application/json");
+            result = new BodyDataTransformResult(new UTF8Encoding(false).GetBytes(json), contentTypeHeaderValues.ToString(), "application/json");
+            return true;
         }
     }
 }

--- a/samples/HelloRin/Views/Home/Index.cshtml
+++ b/samples/HelloRin/Views/Home/Index.cshtml
@@ -24,6 +24,7 @@
             <li><a href="/MyApi/LongResult">Slow stream</a></li>
             <li><a href="/MyApi/Timeline">Timeline scopes</a></li>
             <li><a href="/MyApi/InvokeGrpc">gRPC Request/Response</a></li>
+            <li><a href="/MyApi/CustomContentType">View MessagePack as JSON</a></li>
         </ul>
     </div>
     <div class="col-md-3">

--- a/src/Rin/Core/BodyDataTransformResult.cs
+++ b/src/Rin/Core/BodyDataTransformResult.cs
@@ -1,12 +1,12 @@
-﻿namespace Rin.Core
+namespace Rin.Core
 {
-    public struct BodyDataTransformResult
+    public readonly struct BodyDataTransformResult
     {
-        public string? TransformedContentType { get; }
+        public string TransformedContentType { get; }
         public string ContentType { get; }
         public byte[] Body { get; }
 
-        public BodyDataTransformResult(byte[] body, string contentType, string? transformedContentType)
+        public BodyDataTransformResult(byte[] body, string contentType, string transformedContentType)
         {
             Body = body;
             ContentType = contentType;

--- a/src/Rin/Core/BodyDataTransformer.cs
+++ b/src/Rin/Core/BodyDataTransformer.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Extensions.Primitives;
 using Rin.Core.Record;
 using System.Linq;
@@ -7,7 +8,7 @@ namespace Rin.Core
     public interface IBodyDataTransformer
     {
         bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues);
-        BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues);
+        bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result);
     }
 
     public interface IRequestBodyDataTransformer : IBodyDataTransformer

--- a/src/Rin/Core/BodyDataTransformerPipeline.cs
+++ b/src/Rin/Core/BodyDataTransformerPipeline.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Primitives;
+using System;
+using Microsoft.Extensions.Primitives;
 using Rin.Core.Record;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,15 +20,16 @@ namespace Rin.Core
             return true;
         }
 
-        public BodyDataTransformResult Transform(HttpRequestRecord record, byte[] body, StringValues contentTypeHeaderValues)
+        public bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result)
         {
             var transformer = _transformers.FirstOrDefault(x => x.CanTransform(record, contentTypeHeaderValues));
             if (transformer != null)
             {
-                return transformer.Transform(record, body, contentTypeHeaderValues);
+                return transformer.TryTransform(record, body, contentTypeHeaderValues, out result);
             }
 
-            return new BodyDataTransformResult(body, contentTypeHeaderValues.ToString(), null);
+            result = default;
+            return false;
         }
     }
 }

--- a/src/Rin/Core/Record/IRecordStorage.cs
+++ b/src/Rin/Core/Record/IRecordStorage.cs
@@ -1,4 +1,4 @@
-﻿using Rin.Core.Event;
+using Rin.Core.Event;
 using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace Rin.Core.Record
         Task<RecordStorageTryGetResult<byte[]?>> TryGetRequestBodyByIdAsync(string id);
     }
 
-    public struct RecordStorageTryGetResult<T>
+    public readonly struct RecordStorageTryGetResult<T>
     {
         public bool Succeed { get; }
         public T Value { get; }

--- a/src/Rin/Hubs/RinCoreHub.cs
+++ b/src/Rin/Hubs/RinCoreHub.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Primitives;
+using Microsoft.Extensions.Primitives;
 using Rin.Channel;
 using Rin.Core;
 using Rin.Core.Event;

--- a/src/Rin/Hubs/RinCoreHub.cs
+++ b/src/Rin/Hubs/RinCoreHub.cs
@@ -16,14 +16,12 @@ namespace Rin.Hubs
 {
     public class RinCoreHub : IHub
     {
-        private IRecordStorage _storage;
-        private RinChannel _rinChannel;
-        private BodyDataTransformerSet _bodyDataTransformerSet;
+        private readonly IRecordStorage _storage;
+        private readonly BodyDataTransformerSet _bodyDataTransformerSet;
 
-        public RinCoreHub(IRecordStorage storage, RinChannel rinChannel, BodyDataTransformerSet bodyDataTransformerSet)
+        public RinCoreHub(IRecordStorage storage, BodyDataTransformerSet bodyDataTransformerSet)
         {
             _storage = storage;
-            _rinChannel = rinChannel;
             _bodyDataTransformerSet = bodyDataTransformerSet;
         }
 
@@ -73,7 +71,7 @@ namespace Rin.Hubs
 
         public class MessageSubscriber : IMessageSubscriber<RequestEventMessage>
         {
-            private IRinCoreHubClient _client;
+            private readonly IRinCoreHubClient _client;
             public MessageSubscriber(RinChannel channel)
             {
                 _client = channel.GetClient<RinCoreHub, IRinCoreHubClient>();

--- a/src/Rin/Middlewares/ChannelMiddleware.cs
+++ b/src/Rin/Middlewares/ChannelMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Rin.Channel;
 using Rin.Core;
 using Rin.Core.Event;
@@ -49,7 +49,7 @@ namespace Rin.Middlewares
                 {
                     case nameof(RinCoreHub):
                     default:
-                        hub = new RinCoreHub(_storage, _rinChannel, _bodyDataTransformerSet);
+                        hub = new RinCoreHub(_storage, _bodyDataTransformerSet);
                         break;
                 }
 


### PR DESCRIPTION
## Breaking changes
`IBodyDataTransformer.Transform` method has been changed to `IBodyDataTransformer.TryTransform`.

```csharp
bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result);
```