### PR TITLE
feat: Add Rin.Extensions.MagicOnion

### DIFF
--- a/Rin.sln
+++ b/Rin.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rin.Extensions.EntityFramew
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rin.Extensions.Log4NetAppender", "src\Rin.Extensions.Log4NetAppender\Rin.Extensions.Log4NetAppender.csproj", "{97666ECB-FD39-42CC-B896-5E20B89CE1EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rin.Extensions.MagicOnion", "src\Rin.Extensions.MagicOnion\Rin.Extensions.MagicOnion.csproj", "{F73CA06F-80DB-46B4-AEAB-A01AA6311C2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,10 @@ Global
 		{97666ECB-FD39-42CC-B896-5E20B89CE1EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97666ECB-FD39-42CC-B896-5E20B89CE1EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97666ECB-FD39-42CC-B896-5E20B89CE1EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F73CA06F-80DB-46B4-AEAB-A01AA6311C2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F73CA06F-80DB-46B4-AEAB-A01AA6311C2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F73CA06F-80DB-46B4-AEAB-A01AA6311C2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F73CA06F-80DB-46B4-AEAB-A01AA6311C2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Rin.Extensions.MagicOnion/MagicOnionRequestBodyDataTransformer.cs
+++ b/src/Rin.Extensions.MagicOnion/MagicOnionRequestBodyDataTransformer.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Grpc.Core;
+using MagicOnion.Server;
+using MessagePack;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Rin.Core;
+using Rin.Core.Record;
+
+namespace Rin.Extensions.MagicOnion
+{
+    public class MagicOnionRequestBodyDataTransformer : IRequestBodyDataTransformer
+    {
+        private readonly MessagePackSerializerOptions _serializerOptions;
+        private readonly MagicOnionServiceDefinition _serviceDefinition;
+
+        public MagicOnionRequestBodyDataTransformer(MagicOnionServiceDefinition serviceDefinition, IOptionsMonitor<MagicOnionOptions> magicOnionOptions)
+        {
+            _serviceDefinition = serviceDefinition;
+            _serializerOptions = magicOnionOptions.CurrentValue.SerializerOptions;
+        }
+
+        public bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues)
+        {
+            // NOTE: Currently, this transformer can handle only Unary request.
+            var methodHandler = _serviceDefinition.MethodHandlers.FirstOrDefault(x => string.Concat("/" + x.ServiceName, "/", x.MethodName) == record.Path);
+            if (methodHandler == null || methodHandler.MethodType != MethodType.Unary)
+            {
+                return false;
+            }
+
+            return contentTypeHeaderValues.Any(x => x == "application/grpc");
+        }
+
+        public bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result)
+        {
+            var methodHandler = _serviceDefinition.MethodHandlers.FirstOrDefault(x => string.Concat("/" + x.ServiceName, "/", x.MethodName) == record.Path);
+            if (methodHandler == null)
+            {
+                result = default;
+                return false;
+            }
+
+            var deserialized = MessagePackSerializer.Deserialize(methodHandler.RequestType, body.Slice(5).ToArray() /* Skip gRPC Compressed Flag + Message length */, _serializerOptions);
+            result = new BodyDataTransformResult(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(deserialized)), "application/grpc", "application/json");
+            return true;
+        }
+    }
+
+    public class MagicOnionResponseBodyDataTransformer : IResponseBodyDataTransformer
+    {
+        private readonly MessagePackSerializerOptions _serializerOptions;
+        private readonly MagicOnionServiceDefinition _serviceDefinition;
+
+        public MagicOnionResponseBodyDataTransformer(MagicOnionServiceDefinition serviceDefinition, IOptionsMonitor<MagicOnionOptions> magicOnionOptions)
+        {
+            _serviceDefinition = serviceDefinition;
+            _serializerOptions = magicOnionOptions.CurrentValue.SerializerOptions;
+        }
+
+        public bool CanTransform(HttpRequestRecord record, StringValues contentTypeHeaderValues)
+        {
+            // NOTE: Currently, this transformer can handle only Unary request.
+            var methodHandler = _serviceDefinition.MethodHandlers.FirstOrDefault(x => string.Concat("/" + x.ServiceName, "/", x.MethodName) == record.Path);
+            if (methodHandler == null || methodHandler.MethodType != MethodType.Unary)
+            {
+                return false;
+            }
+
+            return contentTypeHeaderValues.Any(x => x == "application/grpc");
+        }
+
+        public bool TryTransform(HttpRequestRecord record, ReadOnlySpan<byte> body, StringValues contentTypeHeaderValues, out BodyDataTransformResult result)
+        {
+            var methodHandler = _serviceDefinition.MethodHandlers.FirstOrDefault(x => string.Concat("/" + x.ServiceName, "/", x.MethodName) == record.Path);
+            if (methodHandler == null)
+            {
+                result = default;
+                return false;
+            }
+
+            var deserialized = MessagePackSerializer.Deserialize(methodHandler.UnwrappedResponseType, body.Slice(5).ToArray() /* Skip gRPC Compressed Flag + Message length */, _serializerOptions);
+            result = new BodyDataTransformResult(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(deserialized)), "application/grpc", "application/json");
+            return true;
+        }
+    }
+
+}

--- a/src/Rin.Extensions.MagicOnion/Rin.Extensions.MagicOnion.csproj
+++ b/src/Rin.Extensions.MagicOnion/Rin.Extensions.MagicOnion.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!-- NuGet Package Information -->
+    <Description>This package adds support for MagicOnion to Rin</Description>
+    <PackageTags>Rin MagicOnion</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MagicOnion.Server" Version="4.0.0-preview.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\docs\images\logo.png" Pack="true" PackagePath="\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Rin\Rin.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Rin.Extensions.MagicOnion/Rin.Extensions.MagicOnion.csproj
+++ b/src/Rin.Extensions.MagicOnion/Rin.Extensions.MagicOnion.csproj
@@ -5,6 +5,7 @@
     <!-- NuGet Package Information -->
     <Description>This package adds support for MagicOnion to Rin</Description>
     <PackageTags>Rin MagicOnion</PackageTags>
+    <VersionSuffix>preview</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rin.Extensions.MagicOnion/RinMagicOnionServiceExtensions.cs
+++ b/src/Rin.Extensions.MagicOnion/RinMagicOnionServiceExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+using Rin.Extensions;
+using Rin.Extensions.MagicOnion;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class RinMagicOnionServiceExtensions
+    {
+        /// <summary>
+        /// Adds Rin extension services for MagicOnion.
+        /// </summary>
+        /// <param name="builder"></param>
+        public static IRinBuilder AddMagicOnionSupport(this IRinBuilder builder)
+        {
+            builder.AddRequestBodyDataTransformer<MagicOnionRequestBodyDataTransformer>();
+            builder.AddResponseBodyDataTransformer<MagicOnionResponseBodyDataTransformer>();
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Implements BodyDataTransformer for MagicOnion Unary service calls.

Rin.Extensions.MagicOnion adds the ability to decode MagicOnion's request/response body data.
The extension requires MagicOnion 4.0.0-preview.1 or later.

```csharp
services.AddRin()
    .AddMagicOnionSupport();
```