### PR TITLE
Fix throwing exception when Trailers is not available

### DIFF
--- a/src/Rin/Middlewares/RequestRecorderMiddleware.cs
+++ b/src/Rin/Middlewares/RequestRecorderMiddleware.cs
@@ -149,17 +149,6 @@ namespace Rin.Middlewares
             record.ResponseStatusCode = response.StatusCode;
             record.ResponseHeaders = response.Headers.ToDictionary(k => k.Key, v => v.Value);
 
-            if (request.SupportsTrailers())
-            {
-                var trailers = context.Features.Get<IHttpRequestTrailersFeature>();
-                record.RequestTrailers = trailers.Trailers.ToDictionary(k => k.Key, v => v.Value);
-            }
-            if (response.SupportsTrailers())
-            {
-                var trailers = context.Features.Get<IHttpResponseTrailersFeature>();
-                record.ResponseTrailers = trailers.Trailers.ToDictionary(k => k.Key, v => v.Value);
-            }
-
             if (options.RequestRecorder.EnableBodyCapturing)
             {
                 var feature = context.Features.Get<IRinRequestRecordingFeature>();
@@ -173,6 +162,17 @@ namespace Rin.Middlewares
                 {
                     await _eventBusStoreBody.PostAsync(new StoreBodyEventMessage(StoreBodyEvent.Response, record.Id, feature.ResponseDataStream.GetCapturedData()));
                 }
+            }
+
+            if (request.CheckTrailersAvailable())
+            {
+                var trailers = context.Features.Get<IHttpRequestTrailersFeature>();
+                record.RequestTrailers = trailers.Trailers.ToDictionary(k => k.Key, v => v.Value);
+            }
+            if (response.SupportsTrailers())
+            {
+                var trailers = context.Features.Get<IHttpResponseTrailersFeature>();
+                record.ResponseTrailers = trailers.Trailers.ToDictionary(k => k.Key, v => v.Value);
             }
 
             var exceptionFeature = context.Features.Get<IExceptionHandlerFeature>();


### PR DESCRIPTION
`Rin.Middlewares.RequestRecorderMiddleware` sometimes outputs error logs saying:

```
Unhandled Exception was thrown until post-processing

System.InvalidOperationException
The request trailers are not available yet. They may not be available until the full request body is read.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.Microsoft.AspNetCore.Http.Features.IHttpRequestTrailersFeature.get_Trailers()
   at Rin.Middlewares.RequestRecorderMiddleware.PostprocessAsync(HttpContext context, RinOptions options, HttpRequestRecord record)
   at Rin.Middlewares.RequestRecorderMiddleware.InvokeAsync(HttpContext context, RinOptions options)
```

This exception is thrown when `IHttpRequestTrailersFeature` feature is available but `IHttpRequestTrailersFeature.Available` is `false`. So checking whether that property is `true` is needed to read trailer.

This pull request has these changes:

- Read `Trailers` property after reading the body to let the HTTP server read trailer
- Use `CheckTrailersAvailable` instead of `SupportsTrailers` to prevent failure to read `Trailers`