### PR TITLE
fix: Use the original Content-Type value if BodyTransformer is not available

### DIFF
--- a/src/Rin/Hubs/Payloads/BodyDataPayload.cs
+++ b/src/Rin/Hubs/Payloads/BodyDataPayload.cs
@@ -38,6 +38,10 @@ namespace Rin.Hubs.Payloads
                     transformedBodyContentType = result.TransformedContentType;
                     payloadBody = result.Body;
                 }
+                else
+                {
+                    payloadBodyContentType = contentType;
+                }
             }
 
             if (payloadBodyContentType.StartsWith("text/") ||


### PR DESCRIPTION
fix #68 